### PR TITLE
Make header simpler and use universal command as example

### DIFF
--- a/lessons/pydata/notebook/index.md
+++ b/lessons/pydata/notebook/index.md
@@ -209,11 +209,11 @@ buňku místo jednoho řádku.
 
 Seznam všech speciálních příkazů lze získat pomocí `%lsmagic`.
 
-### Příkazy shellu
+### Příkazy z příkazové řádky
 
 V buňkách notebooku je možné velmi snadno spouštět i příkazy z příkazové řádky.
 Příkaz ke spuštění v příkazové řádce místo Pythonu stačí začít znakem vykřičníku
-(např.: `!ls`)
+(např.: `!whoami`)
 
 ## Pokračování
 


### PR DESCRIPTION
*shell* se na začátečnickém kurzu skoro vůbec nepoužívá a může mást (feedback z review)

Jako příklad bych volil univerzální příkaz, který funguje stejně na Linuxu i Windows, aby to nemátlo lidi, kteří `ls` neznají.