### PR TITLE
Fix: title attribute on img tag

### DIFF
--- a/lessons/pydata/eda-univariate-timeseries/index.ipynb
+++ b/lessons/pydata/eda-univariate-timeseries/index.ipynb
@@ -83,9 +83,9 @@
     "\n",
     "Takto vypadají náhledy dvou listů ze souboru `P1PRUZ01.xls`, který obsahuje historická data z meteorologických měření v Praze - Ruzyni. Data jsou poměrně nepěkně uspořádána. Ani v Excelu by se s těmito soubory nepracovalo dobře ...\n",
     "\n",
-    "![thumb_geografie.png](static/thumb_geografie.png \"Sheet 1\")\n",
+    "![thumb_geografie.png](static/thumb_geografie.png)\n",
     "\n",
-    "![thumb_teplota.png](static/thumb_teplota.png \"Sheet 2\")"
+    "![thumb_teplota.png](static/thumb_teplota.png)"
    ]
   },
   {
@@ -4138,7 +4138,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
V EDA 3  se objevil `<img>` tag, který nešel vyrenderovat v naucse, protože měl atribut `title`

Mohl za to tento markdown: `![thumb_geografie.png](static/thumb_geografie.png "Sheet 1")`. Asi bylo cílem to mít spíš jako alt, ne? 

Každopádně jsem to opravil (dočasně?), abychom vůbec měli na webu aktuální instalační instrukce. 